### PR TITLE
STALE-BRANCH-BACKUP - Release candidate v1.6+build.138

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>build-monitor-plugin</artifactId>
-    <version>1.6-SNAPSHOT</version>
+    <version>1.6+build.138</version>
     <packaging>hpi</packaging>
 
     <name>Build Monitor View</name>


### PR DESCRIPTION
This branch has been considered as a stale one. More than 3 months has passed from the last activity. This PR serves the backup purposes for easier restoration. 