### PR TITLE
STALE-BRANCH-BACKUP - Release candidate v1.10+build.201701072019

### DIFF
--- a/build-monitor-acceptance/pom.xml
+++ b/build-monitor-acceptance/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>build-monitor</artifactId>
-        <version>1.10-SNAPSHOT</version>
+        <version>1.10+build.201701072019</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/build-monitor-plugin/pom.xml
+++ b/build-monitor-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>build-monitor</artifactId>
-        <version>1.10-SNAPSHOT</version>
+        <version>1.10+build.201701072019</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>build-monitor</artifactId>
-    <version>1.10-SNAPSHOT</version>
+    <version>1.10+build.201701072019</version>
     <packaging>pom</packaging>
 
     <name>Build Monitor</name>


### PR DESCRIPTION
This branch has been considered as a stale one. More than 3 months has passed from the last activity. This PR serves the backup purposes for easier restoration. 